### PR TITLE
[Fix] Cold boot 시 라우팅이 되지 않는 문제 수정

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -24,7 +24,7 @@ function addTokenToCookie(token: string) {
 }
 
 export default function RootLayout() {
-  const { push, replace } = useRouter();
+  const { replace } = useRouter();
   const [isReady, setIsReady] = useState(false);
 
   useEffect(() => {
@@ -61,7 +61,7 @@ export default function RootLayout() {
     return () => {
       responseListener.remove();
     };
-  }, [push, replace, isReady]);
+  }, [replace, isReady]);
 
   useEffect(() => {
     const checkVersion = async () => {


### PR DESCRIPTION
## ✨ 요약

- `getLastNotificationResponse`를 추가하여 background에서 수신한 notification에도 정상적으로 라우팅이 되도록 수정했습니다.
- `isReady`를 추가해서 완전히 실행된 후 (=== Stack이 완전이 attach 된 후) 라우팅 처리를 하도록 수정했습니다.
- 프론트엔드 로직이 변경됨에 따라, `push` 대신 `replace`를 사용하여 헤더 뒤로가기 아이콘 클릭 시 화면에 중복으로 뜨는 문제를 해결했습니다.
- 이제 안 쓰는 `push`를 제거했습니다.

## 😎 해결한 이슈

- close #26 
