### PR TITLE
[Fix] 카카오톡 앱으로 로그인이 불가능한 문제 수정

### DIFF
--- a/app/webview/[path].tsx
+++ b/app/webview/[path].tsx
@@ -1,5 +1,14 @@
 import { useRef, useEffect } from 'react';
-import { BackHandler, Platform, StatusBar, StyleSheet, Linking, Alert, AppState, AppStateStatus } from 'react-native';
+import {
+  BackHandler,
+  Platform,
+  StatusBar,
+  StyleSheet,
+  Linking,
+  Alert,
+  AppState,
+  AppStateStatus,
+} from 'react-native';
 import { Slot, useLocalSearchParams } from 'expo-router';
 import { WebView } from 'react-native-webview';
 import { SafeAreaView } from 'react-native-safe-area-context';
@@ -8,6 +17,7 @@ import { generateUserAgent } from '../../utils/userAgent';
 import { ShouldStartLoadRequest } from 'react-native-webview/lib/WebViewTypes';
 
 const WEB_URL = 'https://agit.gg';
+const ALLOWED_URL_SCHEMES = ['kakaotalk', 'nidlogin'];
 const userAgent = generateUserAgent();
 
 const handleOnShouldStartLoadWithRequest = ({ url }: ShouldStartLoadRequest) => {
@@ -15,7 +25,8 @@ const handleOnShouldStartLoadWithRequest = ({ url }: ShouldStartLoadRequest) => 
   if (url === 'about:blank') return false;
   (async () => {
     try {
-      if (await Linking.canOpenURL(url)) {
+      const scheme = url.split(':')[0]?.toLowerCase();
+      if ((await Linking.canOpenURL(url)) || ALLOWED_URL_SCHEMES.includes(scheme)) {
         await Linking.openURL(url);
       } else {
         Alert.alert('앱이 설치되지 않았습니다.');
@@ -66,7 +77,9 @@ export default function Index() {
       <StatusBar barStyle={'dark-content'} />
       <WebView
         ref={webViewRef}
-        onNavigationStateChange={(navState) => { canGoBackRef.current = navState.canGoBack; }}
+        onNavigationStateChange={(navState) => {
+          canGoBackRef.current = navState.canGoBack;
+        }}
         source={{ uri: `${WEB_URL}/${local.path ?? ''}` }}
         style={styles.webview}
         javaScriptEnabled


### PR DESCRIPTION
## ✨ 요약
- `ALLOWED_URL_SCHEMES`에 카카오톡 및 네이버 로그인 url scheme을 추가했습니다.
- [공식문서](https://reactnative.dev/docs/linking#canopenurl) 에 따르면, `AndroidManifest.xml`와 `Info.plist`에 선언되지 않은 Scheme에 대해서는 `canOpenURL`이 `false`를 리턴한다고 합니다.
- 안드 네이버 로그인은 아마 네이버 앱이 브라우저 앱이라 작동한 것 같고, 카카오톡은 별도의 scheme이 정의되지 않아 발생한 문제입니다.
- 어차피 플랫폼 별 코드에 선언하느니... 이렇게 선언하는거랑 별반 차이가 없어 보여서 이런식으로 구현했습니다.

## 😎 해결한 이슈

- close #29 
