### PR TITLE
[feat] 외부 브라우저 사용 및 하단 safe area 제거

### DIFF
--- a/app/webview/[path].tsx
+++ b/app/webview/[path].tsx
@@ -135,7 +135,10 @@ export default function Index() {
   }
 
   return (
-    <SafeAreaView style={styles.container} edges={['top', 'left', 'right']}>
+    <SafeAreaView
+      style={styles.container}
+      edges={Platform.OS === 'ios' ? ['top', 'left', 'right'] : undefined}
+    >
       <StatusBar barStyle={'dark-content'} />
       <WebView
         ref={webViewRef}


### PR DESCRIPTION
ios에서 구글 폼 등 외부 링크를 클릭했을 때 웹뷰에서 바로 켜짐으로 인해 생기는 문제를 수정했습니다.
디자이너님께서 이야기 해주신 아이폰 16에서 하단 여백이 생기는 문제를 해결하기 위해 전역으로 적용되어 있던 하단 safe-area를 제거했습니다

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * WebView can open links in the external browser for safer navigation.
  * Multi-window support enabled for improved handling of web content.
  * Improved layout spacing to respect device edges and notches on iOS.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->