### PR TITLE
v1.0.7 배포

### DIFF
--- a/app.config.ts
+++ b/app.config.ts
@@ -11,7 +11,7 @@ const googleServicesFile =
 const config: ExpoConfig = {
   name: appName,
   slug: 'konect-react-native',
-  version: '1.0.6',
+  version: '1.0.7',
   orientation: 'portrait',
   icon: './assets/images/icon.png',
   scheme: 'konect',
@@ -20,13 +20,13 @@ const config: ExpoConfig = {
     supportsTablet: true,
     usesAppleSignIn: true,
     bundleIdentifier: packageName,
-    buildNumber: '1010606',
+    buildNumber: '1010700',
     infoPlist: {
       ITSAppUsesNonExemptEncryption: false,
     },
   },
   android: {
-    versionCode: 1010602,
+    versionCode: 1010700,
     package: packageName,
     googleServicesFile: googleServicesFile,
   },


### PR DESCRIPTION
릴리즈 노트
- 버전 정보 주입을 통한 동적 버전정보 표시 추가
- expo를 비롯한 주요 라이브러리 버전 업
- iOS 키보드 액세서리 툴 제거